### PR TITLE
Issue 1771: fix number inputs for badge and zipcode on IE 11

### DIFF
--- a/forms/officer-complaint-form/package.json
+++ b/forms/officer-complaint-form/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@cityofaustin/us-forms-system": "1.1.7",
     "@ibm/plex": "^1.2.3",
+    "core-js": "^3.0.1",
     "date-fns": "^1.30.1",
     "dotenv": "^7.0.0",
     "dotenv-expand": "^5.1.0",

--- a/forms/officer-complaint-form/src/app.js
+++ b/forms/officer-complaint-form/src/app.js
@@ -1,3 +1,5 @@
+import 'core-js/es/number'; // polyfill for IE 11 number inputs
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useRouterHistory } from 'react-router';

--- a/forms/officer-complaint-form/yarn.lock
+++ b/forms/officer-complaint-form/yarn.lock
@@ -2563,6 +2563,11 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
+core-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+  integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"

--- a/forms/officer-thank-form/package.json
+++ b/forms/officer-thank-form/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@cityofaustin/us-forms-system": "1.1.7",
     "@ibm/plex": "^1.2.3",
+    "core-js": "^3.0.1",
     "date-fns": "^1.30.1",
     "dotenv": "^7.0.0",
     "dotenv-expand": "^5.1.0",

--- a/forms/officer-thank-form/src/app.js
+++ b/forms/officer-thank-form/src/app.js
@@ -1,3 +1,5 @@
+import 'core-js/es/number'; // polyfill for IE 11 number inputs
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useRouterHistory } from 'react-router';

--- a/forms/officer-thank-form/yarn.lock
+++ b/forms/officer-thank-form/yarn.lock
@@ -2563,6 +2563,11 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
+core-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+  integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"

--- a/shared/chapters/OPO/chapters/aboutYouChapter.js
+++ b/shared/chapters/OPO/chapters/aboutYouChapter.js
@@ -28,8 +28,7 @@ const aboutYouChapter = {
           ...genderBlocks.schema,
           ...raceBlocks.schema,
           zipCode: {
-            type: 'number',
-            minimum: 5,
+            type: 'number'
           },
           'view:contactHeader': {
             type: 'object',


### PR DESCRIPTION
cityofaustin/techstack#1771

Primarily concerning
- badge numbers for officers
- zip code for about-you

Browser:
Windows 10, IE 11

Link to pr deployment:
https://opo.austintexas.io/police-complain/1771-badge/

QA Test Criteria:
1. Fill out form with a police badge number and a zip code in the about you page.
2. Check that those numbers show up on the review page.
3. Make sure you can edit those numbers on the review page.
4. Send a confirmation email to yourself.
5. Make sure the confirmation email contains the numbers you entered.

Once this Review/QA is confirmed, then we'll merge it into master and close this issue.